### PR TITLE
SQL Service discovery scan Ending with : Exception calling "EndInvoke…

### DIFF
--- a/Modules/NetworkScan/NetworkScan.psm1
+++ b/Modules/NetworkScan/NetworkScan.psm1
@@ -41,12 +41,12 @@ function Get-ActiveDirectoryDnsConfiguration {
 	param
 	(
 		[Parameter(
-				ValueFromPipeline=$true,
-				ValueFromPipelineByPropertyName=$true,
-		HelpMessage='What computer name would you like to target?')]
+			ValueFromPipeline=$True,
+			ValueFromPipelineByPropertyName=$True,
+			HelpMessage='What computer name would you like to target?')]
 		[Alias('host')]
 		[ValidateLength(3,30)]
-		[string[]]$ComputerName = 'localhost'
+		[string[]]$ComputerName = "localhost"
 	)
 	process {
 
@@ -74,10 +74,10 @@ function Get-ActiveDirectoryDnsConfiguration {
 
 				if (($Domain) -and ($_.DnsServerSearchOrder)) {
 					$ActiveDirectoryDnsConfiguration += (
-						New-Object -TypeName psobject -Property @{
+						New-Object -TypeName psobject -Property @{ 
 							ComputerName = $Computer
-							Domain       = $Domain
-							DnsServer    = $_.DnsServerSearchOrder
+							Domain = $Domain
+							DnsServer = $_.DnsServerSearchOrder
 						}
 					)
 				}
@@ -92,9 +92,9 @@ function Get-IPv4SubnetConfiguration {
 	param
 	(
 		[Parameter(
-				ValueFromPipeline=$true,
-				ValueFromPipelineByPropertyName=$true,
-		HelpMessage='What computer name would you like to target?')]
+			ValueFromPipeline=$True,
+			ValueFromPipelineByPropertyName=$True,
+			HelpMessage='What computer name would you like to target?')]
 		[Alias('host')]
 		[ValidateLength(3,30)]
 		[string[]]$ComputerName = $env:COMPUTERNAME
@@ -114,8 +114,8 @@ function Get-IPv4SubnetConfiguration {
 				# Only work w\ IPv4 addresses
 				if (($_.IPAddress[$pos] -as [System.Net.IPAddress]).AddressFamily -ieq 'InterNetwork') {
 					$IPv4SubnetConfiguration += (
-						New-Object -TypeName psobject -Property @{
-							IPAddress  = $_.IPAddress[$pos]
+						New-Object -TypeName psobject -Property @{ 
+							IPAddress = $_.IPAddress[$pos]
 							SubnetMask = $_.IPSubnet[$pos]
 						}
 					) 
@@ -132,14 +132,14 @@ function Get-DnsARecord {
 	param
 	(
 		[Parameter(
-				Mandatory=$true,
-		HelpMessage='What is the IP Address of the DNS Server you would like to target?')]
+			Mandatory=$true,
+			HelpMessage='What is the IP Address of the DNS Server you would like to target?')]
 		[Alias('ip')]
 		[System.Net.IPAddress[]]$DnsServerIPAddress
 		,
 		[Parameter(
-				Mandatory=$true,
-		HelpMessage='What is the Domain you would like to target?')]
+			Mandatory=$true,
+			HelpMessage='What is the Domain you would like to target?')]
 		[string]$Domain
 	)
 	begin {
@@ -202,11 +202,11 @@ function Get-DeviceScanObject {
 	process {
 		Write-Output (
 			New-Object -TypeName PSObject -Property @{
-				DnsRecordName  = $DnsRecordName
+				DnsRecordName = $DnsRecordName
 				WmiMachineName = $WmiMachineName
-				IPAddress      = $IPAddress
-				IsPingAlive    = $IsPingAlive
-				IsWmiAlive     = $IsWmiAlive
+				IPAddress = $IPAddress
+				IsPingAlive = $IsPingAlive
+				IsWmiAlive = $IsWmiAlive 
 			}
 		)
 	}
@@ -245,114 +245,114 @@ function Write-NetworkScanLog {
 
 function Find-IPv4Device {
 	<#
-		.SYNOPSIS
+	.SYNOPSIS
 		Synchronously look for IPv4 devices on a network.
 
-		.DESCRIPTION
+	.DESCRIPTION
 		This function executes a synchronus scan for IPv4 devices on a network.
-
+		
 		When an IPv4 device is found connectivity via Windows Management Interface (WMI) is also verified.
 
-		.PARAMETER  DnsServer
+	.PARAMETER  DnsServer
 		'Automatic', or the Name or IP address of an Active Directory DNS server to query for a list of hosts to test for connectivity
 
 		When 'Automatic' is specified the function will use WMI queries to discover the current computer's DNS server(s) to query.
-
-		.PARAMETER  DnsDomain
+		
+	.PARAMETER  DnsDomain
 		'Automatic' or the Active Directory domain name to use when querying DNS for a list of hosts.
-
+		
 		When 'Automatic' is specified the function will use the current computer's AD domain.
-
+		
 		'Automatic' will be used by default if DnsServer is specified but DnsDomain is not provided.
 
-		.PARAMETER  Subnet
+	.PARAMETER  Subnet
 		'Automatic' or a comma delimited list of subnets (in CIDR notation) to scan for connectivity.
-
+		
 		When 'Automatic' is specified the function will use the current computer's IP configuration to determine subnets to scan. 
-
+		
 		A quick refresher on CIDR notation:
 
-            BITS    SUBNET MASK        USABLE HOSTS PER SUBNET
-            ----    ---------------    -----------------------
-            /20	    255.255.240.0      4094
-            /21	    255.255.248.0      2046
-            /22	    255.255.252.0      1022
-            /23	    255.255.254.0      510
-            /24	    255.255.255.0      254
-            /25	    255.255.255.128    126
-            /26	    255.255.255.192    62
-            /27	    255.255.255.224    30
-            /28	    255.255.255.240    14
-            /29	    255.255.255.248    6
-            /30	    255.255.255.252    2
-            /32	    255.255.255.255    1
+			BITS	SUBNET MASK			USABLE HOSTS PER SUBNET
+			----	---------------		-----------------------
+			/20		255.255.240.0		4094
+			/21		255.255.248.0		2046 
+			/22		255.255.252.0		1022
+			/23		255.255.254.0		510 
+			/24		255.255.255.0		254 
+			/25		255.255.255.128		126 
+			/26		255.255.255.192		62
+			/27		255.255.255.224		30
+			/28		255.255.255.240		14
+			/29		255.255.255.248		6
+			/30		255.255.255.252		2
+			/32		255.255.255.255		1		
 
-		.PARAMETER  ComputerName
+	.PARAMETER  ComputerName
 		A comma delimited list of computer names to test for connectivity.
-
-		.PARAMETER  ExcludeSubnet
+		
+	.PARAMETER  ExcludeSubnet
 		A comma delimited list of subnets (in CIDR notation) to exclude when testing for connectivity.
-
-		.PARAMETER  LimitSubnet
+		
+	.PARAMETER  LimitSubnet
 		A comma delimited list of subnets (in CIDR notation) to limit the scope of connectivity tests. Only hosts with IP Addresses that fall within the specified subnet(s) will be included in the results.
 
-		.PARAMETER  ExcludeComputerName
+	.PARAMETER  ExcludeComputerName
 		A comma delimited list of computer names to exclude when testing for connectivity. Wildcards are accepted.
-
-		An attempt will be made to resolve the IP Address(es) for each computer in this list and those addresses will also be used when determining if a host should be included or excluded when testing for connectivity.
-
-		.PARAMETER  MaxConcurrencyThrottle
+		
+		An attempt will be made to resolve the IP Address(es) for each computer in this list and those addresses will also be used when determining if a host should be included or excluded when testing for connectivity.		
+		
+	.PARAMETER  MaxConcurrencyThrottle
 		Number between 1-100 to indicate how many instances to collect information from concurrently.
 
 		If not provided then the number of logical CPUs present to your session will be used.
 
-		.PARAMETER  PrivateOnly
+	.PARAMETER  PrivateOnly
 		Only include hosts with private class A, B, or C IP addresses
 
-		.PARAMETER  ResolveAliases
+	.PARAMETER  ResolveAliases
 		When a mismatch between host name and WMI machine name occurs query DNS for the machine name
+		
+	.PARAMETER  ParentProgressId
+		If the caller is using Write-Progress then all progress information will be written using ParentProgressId as the ParentID		
 
-		.PARAMETER  ParentProgressId
-		If the caller is using Write-Progress then all progress information will be written using ParentProgressId as the ParentID
-
-		.PARAMETER  TimeoutSeconds
+	.PARAMETER  TimeoutSeconds
 		Number of seconds to wait for WMI connectivity test to return before timing out.
-
+		
 		If not provided then 30 seconds is used as the default.
 
-		.EXAMPLE
+	.EXAMPLE
 		Find-IPv4Device -DNSServer automatic -DNSDomain automatic -PrivateOnly
-
+		
 		Description
 		-----------
 		Queries Active Directory for a list of hosts to scan for IPv4 connectivity. The list of hosts will be restricted to private IP addresses only.
 
-		.EXAMPLE
+	.EXAMPLE
 		Find-IPv4Device -Subnet 172.20.40.0/28
-
+		
 		Description
 		-----------
 		Scans all hosts in the subnet 172.20.40.0/28 for IPv4 connectivity.
-
-		.EXAMPLE
+		
+	.EXAMPLE
 		Find-IPv4Device -Computername Server1,Server2,Server3
-
+		
 		Description
 		-----------
 		Scanning Server1, Server2, and Server3 for IPv4 connectivity.
 
-		.OUTPUTS
+	.OUTPUTS
 		System.Management.Automation.PSObject
 
-		.NOTES
+	.NOTES
 
-	#>
+#>
 	[CmdletBinding(DefaultParametersetName='dns')]
 	param(
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='dns',
-				HelpMessage='DNS Server(s)'
+			Mandatory=$true,
+			ParameterSetName='dns',
+			HelpMessage='DNS Server(s)'
 		)] 
 		[alias('dns')]
 		[ValidatePattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^auto$|^automatic$')]
@@ -360,27 +360,27 @@ function Find-IPv4Device {
 		$DnsServer = 'automatic'
 		,
 		[Parameter(
-				Mandatory=$false,
-				ParameterSetName='dns',
-				HelpMessage='DNS Domain Name'
+			Mandatory=$false,
+			ParameterSetName='dns',
+			HelpMessage='DNS Domain Name'
 		)] 
 		[alias('domain')]
 		[string]
 		$DnsDomain = 'automatic'
 		,
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='subnet',
-				HelpMessage='Subnet (in CIDR notation)'
+			Mandatory=$true,
+			ParameterSetName='subnet',
+			HelpMessage='Subnet (in CIDR notation)'
 		)] 
 		[ValidatePattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\\/]\d{1,2}$|^auto$|^automatic$')]
 		[string[]]
 		$Subnet = 'Automatic'
 		,
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='computername',
-				HelpMessage='Computer Name(s)'
+			Mandatory=$true,
+			ParameterSetName='computername',
+			HelpMessage='Computer Name(s)'
 		)] 
 		[alias('Computer')]
 		[string[]]
@@ -543,10 +543,10 @@ function Find-IPv4Device {
 					$ActiveDirDnsConfig = @(Get-ActiveDirectoryDnsConfiguration -ComputerName localhost)
 				} else {
 					$ActiveDirDnsConfig = @(
-						New-Object -TypeName psobject -Property @{
+						New-Object -TypeName psobject -Property @{ 
 							ComputerName = $Computer
-							Domain       = $DnsDomain
-							DnsServer    = $DnsServer
+							Domain = $DnsDomain
+							DnsServer = $DnsServer
 						}
 					)
 				}
@@ -590,7 +590,7 @@ function Find-IPv4Device {
 
 							# Check if the host IP is within the ranges for $LimitSubnet and $ExcludeSubnet
 							if ($HasMetCriteria -and 
-								($LimitSubnet -or $ExcludeSubnet)
+								(									$LimitSubnet -or $ExcludeSubnet)
 							) {
 
 								$DecimalAddress = ConvertTo-DecimalIP -IPAddress $IPAddress
@@ -634,8 +634,8 @@ function Find-IPv4Device {
 					$Subnet | Select-Object -Unique | ForEach-Object { 
 						$IPv4SubnetConfig += (
 							Get-NetworkSummary -Network $_ | ForEach-Object {
-								New-Object -TypeName psobject -Property @{
-									IPAddress  = $_.NetworkAddress
+								New-Object -TypeName psobject -Property @{ 
+									IPAddress = $_.NetworkAddress
 									SubnetMask = $_.Mask
 								}
 							}
@@ -766,13 +766,13 @@ function Find-IPv4Device {
 			#Add the runspace into the PowerShell instance
 			$PowerShell.RunspacePool = $RunspacePool
 
-			$null = $Runspaces.Add((
+			$Runspaces.Add((
 					New-Object -TypeName PsObject -Property @{
 						PowerShell = $PowerShell
-						Runspace   = $PowerShell.BeginInvoke()
-						HashKey    = $_.Key
+						Runspace = $PowerShell.BeginInvoke()
+						HashKey = $_.Key
 					}
-			))
+				)) | Out-Null
 
 		}
 
@@ -814,13 +814,13 @@ function Find-IPv4Device {
 			Start-Sleep -Milliseconds 250
 
 			# Clean out unused runspace jobs
-			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $null) } | ForEach-Object {
+			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $Null) } | ForEach {
 				$Runspaces.remove($_)
 				$ScanCount++
 				Write-Progress -Activity 'Testing PING connectivity' -PercentComplete (($ScanCount / $DeviceCount)*100) -Status "$ScanCount of $DeviceCount" -Id $PingProgressId -ParentId $ParentProgressId
 			}
 
-		} while (($Runspaces | Where-Object {$_.Runspace -ne $null} | Measure-Object).Count -gt 0)
+		} while (($Runspaces | Where-Object {$_.Runspace -ne $Null} | Measure-Object).Count -gt 0)
 		#endregion
 
 
@@ -845,61 +845,61 @@ function Find-IPv4Device {
 			)
 
 			<#
-				function Get-WMIObjectWithTimeout {
+			function Get-WMIObjectWithTimeout {
 				[CmdletBinding()]
 				param(
-				[Parameter(Mandatory=$false)]
-				[Alias('ns')]
-				[ValidateNotNullOrEmpty()]
-				[System.String]
-				$NameSpace = 'root\CIMV2'
-				,
-				[Parameter(Mandatory=$true)]
-				[ValidateNotNull()]
-				[System.String]
-				$Class
-				,
-				[Parameter(Mandatory=$false)]
-				[ValidateNotNull()]
-				[System.String[]]
-				$Property = @('*')
-				,
-				[Parameter(Mandatory=$false)]
-				[Alias('cn')]
-				[ValidateNotNull()]
-				[System.String]
-				$ComputerName = '.'
-				,
-				[Parameter(Mandatory=$false)]
-				[ValidateNotNull()]
-				[System.String]
-				$Filter
-				,
-				[Parameter(Mandatory=$false)]
-				[Alias('timeout')]
-				[ValidateRange(1,3600)]
-				[Int]
-				$TimeoutSeconds = 600
+					[Parameter(Mandatory=$false)]
+					[Alias('ns')]
+					[ValidateNotNullOrEmpty()]
+					[System.String]
+					$NameSpace = 'root\CIMV2'
+					,
+					[Parameter(Mandatory=$true)]
+					[ValidateNotNull()]
+					[System.String]
+					$Class
+					,
+					[Parameter(Mandatory=$false)]
+					[ValidateNotNull()]
+					[System.String[]]
+					$Property = @('*')
+					,
+					[Parameter(Mandatory=$false)]
+					[Alias('cn')]
+					[ValidateNotNull()]
+					[System.String]
+					$ComputerName = '.'
+					,
+					[Parameter(Mandatory=$false)]
+					[ValidateNotNull()]
+					[System.String]
+					$Filter
+					,
+					[Parameter(Mandatory=$false)]
+					[Alias('timeout')]
+					[ValidateRange(1,3600)]
+					[Int]
+					$TimeoutSeconds = 600
 				)
 				try {
-				$WmiSearcher = [WMISearcher]''
-				$Query = 'select ' + [String]::Join(',',$Property) + ' from ' + $Class
+					$WmiSearcher = [WMISearcher]''
+					$Query = 'select ' + [String]::Join(',',$Property) + ' from ' + $Class
 
-				if ($Filter) {
-				$Query = "$Query where $Filter"
-				}
-				$WmiSearcher.Options.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
-				$WmiSearcher.Options.ReturnImmediately = $true
-				$WmiSearcher.Scope.Path = "\\$ComputerName\$NameSpace"
-				$WmiSearcher.Query = $Query
-				$WmiSearcher.Get() 
+					if ($Filter) {
+						$Query = "$Query where $Filter"
+					}
+					$WmiSearcher.Options.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
+					$WmiSearcher.Options.ReturnImmediately = $true
+					$WmiSearcher.Scope.Path = "\\$ComputerName\$NameSpace"
+					$WmiSearcher.Query = $Query
+					$WmiSearcher.Get() 
 				}
 				catch {
-				Throw
+					Throw
 				}
-				}
+			}
 
-				$Win32_ComputerSystem = Get-WMIObjectWithTimeout -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Name -ComputerName $IPAddress -TimeoutSeconds 60 -ErrorAction Stop
+			$Win32_ComputerSystem = Get-WMIObjectWithTimeout -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Name -ComputerName $IPAddress -TimeoutSeconds 60 -ErrorAction Stop
 			#>
 
 			$Win32_ComputerSystem = Get-WMIObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Name -ComputerName $IPAddress -ErrorAction Stop
@@ -926,14 +926,14 @@ function Find-IPv4Device {
 			# Add the runspace into the PowerShell instance
 			$PowerShell.RunspacePool = $RunspacePool
 
-			$null = $Runspaces.Add((
+			$Runspaces.Add((
 					New-Object -TypeName PsObject -Property @{
 						PowerShell = $PowerShell
-						Runspace   = $PowerShell.BeginInvoke()
-						HashKey    = $_.Key
-						StartDate  = [DateTime]::Now
+						Runspace = $PowerShell.BeginInvoke()
+						HashKey = $_.Key
+						StartDate = [DateTime]::Now
 					}
-			))
+				)) | Out-Null
 
 		}
 
@@ -1016,13 +1016,13 @@ function Find-IPv4Device {
 			Start-Sleep -Milliseconds 250
 
 			# Clean out unused runspace jobs
-			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $null) } | ForEach-Object {
+			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $Null) } | ForEach {
 				$Runspaces.remove($_)
 				$ScanCount++
 				Write-Progress -Activity 'Testing WMI connectivity' -PercentComplete (($ScanCount / $DeviceCount)*100) -Status "$ScanCount of $DeviceCount" -Id $WmiProgressId -ParentId $ParentProgressId
 			}
 
-		} while (($Runspaces | Where-Object {$_.Runspace -ne $null} | Measure-Object).Count -gt 0)
+		} while (($Runspaces | Where-Object {$_.Runspace -ne $Null} | Measure-Object).Count -gt 0)
 
 		#endregion
 
@@ -1053,104 +1053,104 @@ function Find-IPv4Device {
 
 function Find-SqlServerService {
 	<#
-		.SYNOPSIS
+	.SYNOPSIS
 		Synchronously look for SQL Server Services on a network.
 
-		.DESCRIPTION
+	.DESCRIPTION
 		This function executes a synchronus scan for hosts with SQL Server Services on a network.
 
-		.PARAMETER  DnsServer
+	.PARAMETER  DnsServer
 		'Automatic', or the Name or IP address of an Active Directory DNS server to query for a list of hosts to test for connectivity
 
 		When 'Automatic' is specified the function will use WMI queries to discover the current computer's DNS server(s) to query.
-
-		.PARAMETER  DnsDomain
+		
+	.PARAMETER  DnsDomain
 		'Automatic' or the Active Directory domain name to use when querying DNS for a list of hosts.
-
+		
 		When 'Automatic' is specified the function will use the current computer's AD domain.
-
+		
 		'Automatic' will be used by default if DnsServer is specified but DnsDomain is not provided.
 
-		.PARAMETER  Subnet
+	.PARAMETER  Subnet
 		'Automatic' or a comma delimited list of subnets (in CIDR notation) to scan for connectivity.
-
+		
 		When 'Automatic' is specified the function will use the current computer's IP configuration to determine subnets to scan. 
-
+		
 		A quick refresher on CIDR notation:
 
-            BITS    SUBNET MASK        USABLE HOSTS PER SUBNET
-            ----    ---------------    -----------------------
-            /20	    255.255.240.0      4094
-            /21	    255.255.248.0      2046
-            /22	    255.255.252.0      1022
-            /23	    255.255.254.0      510
-            /24	    255.255.255.0      254
-            /25	    255.255.255.128    126
-            /26	    255.255.255.192    62
-            /27	    255.255.255.224    30
-            /28	    255.255.255.240    14
-            /29	    255.255.255.248    6
-            /30	    255.255.255.252    2
-            /32	    255.255.255.255    1
+			BITS	SUBNET MASK			USABLE HOSTS PER SUBNET
+			----	---------------		-----------------------
+			/20		255.255.240.0		4094
+			/21		255.255.248.0		2046 
+			/22		255.255.252.0		1022
+			/23		255.255.254.0		510 
+			/24		255.255.255.0		254 
+			/25		255.255.255.128		126 
+			/26		255.255.255.192		62
+			/27		255.255.255.224		30
+			/28		255.255.255.240		14
+			/29		255.255.255.248		6
+			/30		255.255.255.252		2
+			/32		255.255.255.255		1		
 
-		.PARAMETER  ComputerName
+	.PARAMETER  ComputerName
 		A comma delimited list of of computer names to test for SQL Server services.
 
-		.PARAMETER  ExcludeSubnet
+	.PARAMETER  ExcludeSubnet
 		A comma delimited list of subnets (in CIDR notation) to exclude when testing for connectivity.
-
-		.PARAMETER  LimitSubnet
+		
+	.PARAMETER  LimitSubnet
 		A comma delimited list of subnets (in CIDR notation) to limit the scope of connectivity tests. Only hosts with IP Addresses that fall within the specified subnet(s) will be included in the results.
 
-		.PARAMETER  ExcludeComputerName
+	.PARAMETER  ExcludeComputerName
 		A comma delimited list of computer names to exclude when testing for connectivity. Wildcards are accepted.
+		
+		An attempt will be made to resolve the IP Address(es) for each computer in this list and those addresses will also be used when determining if a host should be included or excluded when testing for connectivity.		
 
-		An attempt will be made to resolve the IP Address(es) for each computer in this list and those addresses will also be used when determining if a host should be included or excluded when testing for connectivity.
-
-		.PARAMETER  MaxConcurrencyThrottle
+	.PARAMETER  MaxConcurrencyThrottle
 		Number between 1-100 to indicate how many instances to collect information from concurrently.
 
 		If not provided then the number of logical CPUs present to your session will be used.
 
-		.PARAMETER  PrivateOnly
+	.PARAMETER  PrivateOnly
 		Only include hosts with private class A, B, or C IP addresses
+		
+	.PARAMETER  ParentProgressId
+		If the caller is using Write-Progress then all progress information will be written using ParentProgressId as the ParentID		
 
-		.PARAMETER  ParentProgressId
-		If the caller is using Write-Progress then all progress information will be written using ParentProgressId as the ParentID
-
-		.EXAMPLE
+	.EXAMPLE
 		Find-SqlServerService -DNSServer automatic -DNSDomain automatic -PrivateOnly
-
+		
 		Description
 		-----------
 		Queries Active Directory for a list of hosts to scan for SQL Server services. The list of hosts will be restricted to private IP addresses only.
 
-		.EXAMPLE
+	.EXAMPLE
 		Find-SqlServerService -Subnet 172.20.40.0/28
-
+		
 		Description
 		-----------
 		Scans all hosts in the subnet 172.20.40.0/28 for SQL Server services.
-
-		.EXAMPLE
+		
+	.EXAMPLE
 		Find-SqlServerService -Computername Server1,Server2,Server3
-
+		
 		Description
 		-----------
 		Scanning Server1, Server2, and Server3 for SQL Server services.
 
-		.OUTPUTS
+	.OUTPUTS
 		System.Management.Automation.PSObject
 
-		.NOTES
+	.NOTES
 
-	#>
+#>
 	[CmdletBinding(DefaultParametersetName='dns')]
 	param(
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='dns',
-				HelpMessage='DNS Server(s)'
+			Mandatory=$true,
+			ParameterSetName='dns',
+			HelpMessage='DNS Server(s)'
 		)] 
 		[alias('dns')]
 		[ValidatePattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^auto$|^automatic$')]
@@ -1158,27 +1158,27 @@ function Find-SqlServerService {
 		$DnsServer = 'automatic'
 		,
 		[Parameter(
-				Mandatory=$false,
-				ParameterSetName='dns',
-				HelpMessage='DNS Domain Name'
+			Mandatory=$false,
+			ParameterSetName='dns',
+			HelpMessage='DNS Domain Name'
 		)] 
 		[alias('domain')]
 		[string]
 		$DnsDomain = 'automatic'
 		,
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='subnet',
-				HelpMessage='Subnet (in CIDR notation)'
+			Mandatory=$true,
+			ParameterSetName='subnet',
+			HelpMessage='Subnet (in CIDR notation)'
 		)] 
 		[ValidatePattern('^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)[\\/]\d{1,2}$|^auto$|^automatic$')]
 		[string[]]
 		$Subnet = 'Automatic'
 		,
 		[Parameter(
-				Mandatory=$true,
-				ParameterSetName='computername',
-				HelpMessage='Computer Name(s)'
+			Mandatory=$true,
+			ParameterSetName='computername',
+			HelpMessage='Computer Name(s)'
 		)] 
 		[alias('Computer')]
 		[string[]]
@@ -1217,9 +1217,7 @@ function Find-SqlServerService {
 	)
 	process {
 
-		$Service = New-Object -TypeName psobject -Property @{
-			Service = @()
-		}
+		$Service = New-Object -TypeName psobject -Property @{ Service = @() }
 		$IPv4Device = @()
 		$ParameterHash = $null
 		$ScanCount = 0
@@ -1244,9 +1242,9 @@ function Find-SqlServerService {
 		# Build command for splatting
 		$ParameterHash = @{
 			MaxConcurrencyThrottle = $MaxConcurrencyThrottle
-			PrivateOnly            = $PrivateOnly
-			ResolveAliases         = $true
-			ParentProgressId       = $ParentProgressId
+			PrivateOnly = $PrivateOnly
+			ResolveAliases = $true
+			ParentProgressId = $ParentProgressId
 		}
 
 		switch ($PsCmdlet.ParameterSetName) {
@@ -1288,441 +1286,145 @@ function Find-SqlServerService {
 		$ScanCount = 0
 		$ScriptBlock = {
 			Param (
-				[String]$IPAddress,
+				[String]$IpAddress,
 				[String]$ComputerName
 			)
 
 			# Load SMO Assemblies
 			[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SMO') | ForEach-Object {
 				if ($_.GetName().Version.Major -ge 10) {
-					$null = [System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SMOExtended')
-					$null = [System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SQLWMIManagement')
+					[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SMOExtended') | Out-Null
+					[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SQLWMIManagement') | Out-Null
 				}
 			}
 
 			# Registry constants
 			New-Variable -Name HKEY_LOCAL_MACHINE -Value 2147483650 -Scope Script -Option Constant
 
-
 			# Variables
+			$InstanceName = $null
+			$IsNamedInstance = $false
+			$IsClusteredInstance = $false
+			$ClusterName = $null
+			$ServiceIpAddress = $null
 			$DomainName = $null
+			$ServiceTypeName = $null
 			$ManagedComputerServerInstanceName = $null
+			$Port = $null
+			$IsDynamicPort = $false
+			$ServiceStartDate = $null
+			$Protocol = $null
+			$NetbiosComputerName = if ($ComputerName.IndexOf('.') -gt 15) {
+				$ComputerName.Substring(0,15)
+			} else {
+				$ComputerName.Split('.')[0]
+			}
 
 			$StdRegProv = $null
-			$RegistryKeyInstanceNameRoot = $null
-			$RegistryKeySoftwareRoot = $null
-			$RegistryKeyInstanceSubkey = $null
-			$RegistryKeyInstanceIdRoot = $null
+			$RegistryKeyRootPath = $null
+			$PathName = $null
+			$StartMode = $null
+			$ProcessId = $null
+			$ServiceState = $null
+			$ServiceAccount = $null
+			$Description = $null
+			$RegistryKeyPath = $null
 			$Parameters = $null
 			$StartupParameters = $null
-			$ServiceCollection = @()
-
-			$SqlService = $null
-			$SqlServiceBase = $null
-			$ServiceFilter = [String]::Empty
-			$IncludeService = [String]::Empty
-			$ExcludeService = [String]::Empty
-			$ServicePropertyList = @('Name','DisplayName','PathName','StartMode','ProcessId','State','StartName','Description')
-			$InstanceId = [String]::Empty
-			$HasWow6432Node = $null
-			$EditionDescriptor = ' (64 Bit)'
 
 
 			$ManagedComputer = New-Object -TypeName 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer' -ArgumentList $ComputerName
 			#$ManagedServiceTypeEnum = 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedServiceType' -as [Type]
 
-			function Get-SqlServiceObject
-			{
-				Write-Output (
-					New-Object -TypeName psobject -Property @{
-						ComputerName        = $null
-						DisplayName         = $null
-						Description         = $null
-						Edition             = $null
-						ComputerIpAddress   = $null
-						InstanceName        = $null
-						IsNamedInstance     = $null
-						IsClusteredInstance = $null
-						IsDynamicPort       = $null
-						IsHadrEnabled       = $null
-						PathName            = $null
-						Port                = $null
-						ProcessId           = $null
-						ServerName          = $null
-						ServiceIpAddress    = $null
-						ServicePackLevel    = $null
-						ServiceProtocols    = $null
-						ServiceStartDate    = $null
-						ServiceState        = $null
-						ServiceTypeName     = $null
-						ServiceAccount      = $null
-						StartMode           = $null
-						StartupParameters   = $null
-						Version             = $null
-						VirtualServerName   = $null
-					}
-				)
-			}
-
-			function Get-RegistryKeyValueEnum
-			{
-				[CmdletBinding()]
-				[OutputType([System.Collections.Hashtable])]
-				Param
-				(
-					[Parameter(Mandatory=$true, Position=0)]
-					[System.Management.ManagementClass]
-					$StdRegProv,
-					[Parameter(Mandatory=$true, Position=1)]
-					[uint32]
-					$RootKey,
-					[Parameter(Mandatory=$true, Position=2)]
-					[string]
-					$SubKey,
-					[Parameter(Mandatory=$false, Position=3)]
-					[string[]]
-					$Exclude = @()
-				)
-
-				Begin
-				{
-					$KeyValue = @{}
-					$Parameters = $null 
-					$i = 0
-					$ValueName = $null
-					$Value = $null
-				}
-				Process
-				{
-					$Parameters = $StdRegProv.EnumValues($RootKey,$SubKey)
-
-					for ($i = 0; $i -lt ($Parameters.sNames | Measure-Object).Count; $i++) {
-
-						$ValueName = '{0}' -f $Parameters.sNames[$i]
-                        
-						if ($Exclude -inotcontains $ValueName) {
-                            
-							switch ($Parameters.Types[$i]) {
-								1 {
-									# REG_SZ
-									$Value = $($StdRegProv.GetStringValue($RootKey,$SubKey,$ValueName)).sValue
-								}
-								2 { 
-									# REG_EXPAND_SZ
-									$Value = $($StdRegProv.GetExpandedStringValue($RootKey,$SubKey,$ValueName)).sValue
-								}
-								3 {
-									# REG_BINARY
-									$Value = [System.BitConverter]::ToString($($StdRegProv.GetBinaryValue($RootKey,$SubKey,$ValueName).uValue) )
-								}
-								4 {
-									# REG_DWORD
-									$Value = $($StdRegProv.GetDWORDValue($RootKey,$SubKey,$ValueName)).uValue
-								}
-								7 {
-									# REG_MULTI_SZ
-									$Value = $($StdRegProv.GetMultiStringValue($RootKey,$SubKey,$ValueName)).sValue | ForEach-Object {
-										$_
-									} 
-								}
-								default { $Value = $null }
-							}
-
-							$KeyValue.Add($ValueName, $Value)
-
-						}
-					}
-                    
-				}
-				End
-				{
-					Write-Output $KeyValue
-					Remove-Variable -Name KeyValue, Parameters, i, ValueName, Value
-				}
-			}
-
-			# Determine an IP Address & port the SQL Server service is listening on (if TCP/IP enabled)
-			function Set-SqlServerServiceIpAddress
-			{
-				[CmdletBinding()]
-				Param
-				(
-					[Parameter(Mandatory=$true,Position=0)]
-					[PSObject]
-					$SqlService
-				)
-				Begin
-				{
-				}
-				Process
-				{
-					$SqlService.ServiceProtocols | 
-					Where-Object { 
-						$_.Name -ieq 'tcp' -and
-						$_.IsEnabled -eq $true
-					} |
-					ForEach-Object {
-
-						# If listening on all IPs then get the "IPAll" port info
-						# Otherwise get port info for an IP that's enabled and active
-
-						if ($_.ProtocolProperties['ListenOnAllIPs'] -eq $true) {
-
-							$_.IPAddresses | 
-							Where-Object { $_.Name -ieq 'ipall' } | 
-							ForEach-Object {
-								$SqlService.Port = $_.IPAddressProperties['TcpPort']
-								if (-not $SqlService.Port) {
-									$SqlService.Port = $_.IPAddressProperties['TcpDynamicPorts']
-									$SqlService.IsDynamicPort = $true
-								} else {
-									$SqlService.IsDynamicPort = $false
-								}
-							}
-
-						} else {
-
-							# Start with 127.0.0.1 first in case that's the only IP that's enabled
-							$_.IPAddresses | 
-							Where-Object {
-								$_.IPAddressProperties['Active'] -eq $true -and 
-								$_.IPAddressProperties['Enabled'] -eq $true -and
-								$_.IPAddressFamily -ieq 'InterNetwork' -and
-								$_.IPAddress -ieq '127.0.0.1'
-							} | 
-							Select-Object -First 1 | 
-							ForEach-Object {
-
-								$SqlService.ServiceIpAddress = $_.IPAddress
-								$SqlService.Port = $_.IPAddressProperties['TcpPort']
-
-								if (-not $SqlService.Port) {
-									$SqlService.Port = $_.IPAddressProperties['TcpDynamicPorts']
-									$SqlService.IsDynamicPort = $true
-								} else {
-									$SqlService.IsDynamicPort = $false
-								}
-							}
-
-							# Now try and see if there's a non-loopback IP enabled
-							$_.IPAddresses | 
-							Where-Object {
-								$_.IPAddressProperties['Active'] -eq $true -and 
-								$_.IPAddressProperties['Enabled'] -eq $true -and
-								$_.IPAddressFamily -ieq 'InterNetwork' -and
-								$_.IPAddress -ine '127.0.0.1'
-							} | 
-							Select-Object -First 1 | 
-							ForEach-Object {
-
-								$SqlService.ServiceIpAddress = $_.IPAddress
-								$SqlService.Port = $_.IPAddressProperties['TcpPort']
-
-								if (-not $SqlService.Port) {
-									$SqlService.Port = $_.IPAddressProperties['TcpDynamicPorts']
-									$SqlService.IsDynamicPort = $true
-								} else {
-									$SqlService.IsDynamicPort = $false
-								}
-							} 
-						}
-					}
-				}
-				End
-				{
-				}
-			}
-
-			function Get-SqlServiceServername
-			{
-				[CmdletBinding()]
-				[OutputType([string])]
-				Param
-				(
-					# Param1 help description
-					[Parameter(Mandatory=$true, Position=0)]
-					[PSObject]
-					$SqlService
-				)
-
-				Begin
-				{
-					$NetbiosComputerName = $SqlService.ComputerName.Split('.')[0].PadRight(15,' ').Substring(0,15).Trim()
-				}
-				Process
-				{
-					if ($SqlService.IsNamedInstance -eq $true) {
-						if ($SqlService.IsClusteredInstance -eq $true) {
-							if ($SqlService.ServiceTypeName -ine 'SQL Server Analysis Services') {
-								[String]::Join('\', @($SqlService.VirtualServerName, $SqlService.InstanceName))
-							} else {
-								# Connections to SSAS on a cluster do not use the instance name - only the cluster name
-								$SqlService.VirtualServerName
-							}
-						} else {
-							if (
-								$SqlService.ServiceTypeName -ine 'SQL Server' -or
-								$(
-									$SqlService.ServiceProtocols | Where-Object {
-										$_.Name -ine 'sm' -and
-										$_.IsEnabled -eq $true
-									}
-								)
-							) {
-								# Another protocol besides shared memory is enabled or the service isn't SQL Server\SQL Server Agent; use the FQDN
-								[String]::Join('\', @($SqlService.ComputerName, $SqlService.InstanceName))
-							} else {
-								# Shared memory is the only protocol enabled; use the NETBIOS name
-								[String]::Join('\', @($NetbiosComputerName, $SqlService.InstanceName))
-							}
-						}
-					} else {
-						if ($SqlService.IsClusteredInstance -eq $true) {
-							$SqlService.VirtualServerName
-						} else {
-							if (
-								$SqlService.ServiceTypeName -ine 'SQL Server' -or
-								$(
-									$SqlService.ServiceProtocols | Where-Object {
-										$_.Name -ine 'sm' -and
-										$_.IsEnabled -eq $true
-									}
-								)
-							) {
-								# Another protocol besides shared memory is enabled or the service isn't SQL Server\SQL Server Agent; use the FQDN
-								$SqlService.ComputerName
-							} else {
-								# Shared memory is the only protocol enabled; use the NETBIOS name
-								$NetbiosComputerName
-							}
-						}
-					}
-
-				}
-				End
-				{
-					Remove-Variable -Name NetbiosComputerName
-				}
-			}
-
-
-			#region WMI Managed Computer Object
-
 			# Try to use the WMI Managed Computer Object to find SQL Services on $ComputerName
 			try {
-				$ManagedComputer.Services | 
-				ForEach-Object {
-
-					$SqlService = Get-SqlServiceObject
-					$SqlService.ComputerName = $ComputerName
-					$SqlService.DisplayName = $_.DisplayName
-					$SqlService.Description = $_.Description
-					$SqlService.Edition = $_.AdvancedProperties['SKUNAME'].Value
-					$SqlService.ComputerIpAddress = $IPAddress
-					$SqlService.IsHadrEnabled = $_.IsHadrEnabled
-					$SqlService.PathName = $_.PathName
-					$SqlService.ProcessId = $_.ProcessId
-					$SqlService.ServiceIpAddress = $null
-					$SqlService.ServicePackLevel = $_.AdvancedProperties['SPLEVEL'].Value
-					$SqlService.ServiceState = $_.ServiceState.ToString()
-					$SqlService.ServiceAccount = $_.ServiceAccount
-					$SqlService.StartMode = $_.StartMode.ToString()
-					$SqlService.StartupParameters = $_.StartupParameters
-					$SqlService.Version = $_.AdvancedProperties['VERSION'].Value
-
+				$ManagedComputer.Services | ForEach-Object {
 
 					if (($_.Name).IndexOf('$') -gt 0) {
-						$SqlService.InstanceName = ($_.Name).Substring(($_.Name).IndexOf('$') + 1)
-						$SqlService.IsNamedInstance = $true
-						$ManagedComputerServerInstanceName = $SqlService.InstanceName
+						$InstanceName = ($_.Name).Substring(($_.Name).IndexOf('$') + 1)
+						$IsNamedInstance = $true
+						$ManagedComputerServerInstanceName = $InstanceName
 					} else {
-						$SqlService.InstanceName = 'MSSQLSERVER'
-						$SqlService.IsNamedInstance = $false
+						$InstanceName = $null
+						$IsNamedInstance = $false
 						$ManagedComputerServerInstanceName = $_.Name
+					}
+
+					# Try and determine if this is a clustered server (and the FQDN & IP for the cluster if it is)
+					try {
+						if ($_.AdvancedProperties['CLUSTERED'].Value -eq $true) {
+							$IsClusteredInstance = $true
+
+							Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IpAddress -ErrorAction Stop | ForEach-Object {
+								$DomainName = $_.Domain
+							}
+
+							$ClusterName = [String]::Join('.', @($_.AdvancedProperties['VSNAME'].Value, $DomainName)).ToUpper()
+
+							[System.Net.Dns]::GetHostByName($ClusterName) | ForEach-Object {
+								$_.AddressList | Where-Object { $_.AddressFamily -ieq 'InterNetwork' } | ForEach-Object {
+									$ServiceIpAddress = $_.IPAddressToString
+								}
+							}
+
+						} else {
+							$IsClusteredInstance = $false
+							$ClusterName = [String]::Empty
+							$ServiceIpAddress = $IpAddress
+						}
+					}
+					catch {
+						$IsClusteredInstance = $false
+						$ClusterName = [String]::Empty
+						$ServiceIpAddress = $IpAddress
 					}
 
 
 					# Get the Friendly name for the service
-					$SqlService.ServiceTypeName = switch ($_.Type.value__) {
-						1 { 'SQL Server' }
-						2 { 'SQL Server Agent' }
-						3 { 'SQL Server FullText Search' }
-						4 { 'SQL Server Integration Services' }
+					$ServiceTypeName = switch ($_.Type.value__) {
 						5 { 'SQL Server Analysis Services' }
+						#$ManagedServiceTypeEnum::NotificationServer { 'SQL Server Notification Services' }
 						6 { 'SQL Server Reporting Services' }
+						#$ManagedServiceTypeEnum::Search { 'Microsoft Search service' }
+						3 { 'SQL Server FullText Search' }
+						2 { 'SQL Server Agent' }
 						7 { 'SQL Server Browser' }
-						8 { 'SQL Server Notification Services' }
+						1 { 'SQL Server' }
+						4 { 'SQL Server Integration Services' }
 						9 { 'SQL Full-text Filter Daemon Launcher' }
+						12 { 'SQL Server Launchpad' }
 						$null { 'Unknown' }
-						default { $_.Type.ToString() }
+						default { $typevalue =  $_.Type.value__
+								  Write-NetworkScanLog -Message "Typevalue $Typevalue not found. Please define a value for variable 'ServiceTypeName'." -MessageLevel Information}
 					}
-
-
-					# Determine if this is a clustered server (and the FQDN for the cluster if it is)
-					# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-					# ...because you can get into some complicated scenarios with multi-subnet clusters that are best left to letting the client resolve
-					# Also, SQL Browser service cannot be clustered but SMO shows that it is so explicitly exclude it
-					if ($_.AdvancedProperties['CLUSTERED'].Value -eq $true -and $SqlService.ServiceTypeName -ine 'SQL Server Browser') {
-
-						$SqlService.VirtualServerName = $_.AdvancedProperties['VSNAME'].Value
-
-						if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-							$SqlService.IsClusteredInstance = $true
-							$SqlService.ServiceIpAddress = $null
-
-							try {
-								if ([String]::IsNullOrEmpty($DomainName)) {
-									Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-									ForEach-Object {
-										$DomainName = $_.Domain
-									}
-								}
-								$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
-							}
-							catch {
-								# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-								$SqlService.VirtualServerName = $_.AdvancedProperties['VSNAME'].Value
-							}
-
-						} else {
-							$SqlService.VirtualServerName = [String]::Empty
-						}
-
-					} else {
-						$SqlService.IsClusteredInstance = $false
-						$SqlService.VirtualServerName = $null
-					}
-
 
 					# Gather protocol details for SQL Server service
-					if ($SqlService.ServiceTypeName -ieq 'SQL Server') {
+					# Not applicable to other service types
+					$ServiceIpAddress = $null
+					$Port = $null
+					$IsDynamicPort = $null
+					$ServiceProtocol = $null
+
+					if ($ServiceTypeName -ieq 'SQL Server') {
 
 						# Gather protocol details
-						$SqlService.ServiceProtocols = $ManagedComputer.ServerInstances | 
-						Where-Object { $_.Name -ieq $ManagedComputerServerInstanceName } | 
-						ForEach-Object {
-							$_.ServerProtocols | 
-							Where-Object { -not [String]::IsNullOrEmpty($_.Name) } | 
-							ForEach-Object {
+						$ServiceProtocol = $ManagedComputer.ServerInstances | Where-Object { $_.Name -ieq $ManagedComputerServerInstanceName } | ForEach-Object {
+							$_.ServerProtocols | Where-Object { -not [String]::IsNullOrEmpty($_.Name) } | ForEach-Object {
 								New-Object -TypeName PSObject -Property @{
-									Name               = $_.Name
-									DisplayName        = $_.DisplayName
-									IsEnabled          = $_.IsEnabled
-									IPAddresses        = $_.IPAddresses |
-									Where-Object { $_.IPAddress } |
-									ForEach-Object {
+									Name = $_.Name
+									DisplayName = $_.DisplayName
+									IsEnabled = $_.IsEnabled
+									IPAddresses = $_.IPAddresses | Where-Object { $_.IPAddress } | ForEach-Object {
 										New-Object -TypeName PSObject -Property @{
-											Name                = $_.Name
-											IpAddress           = $_.IPAddress.ToString()
-											IpAddressFamily     = $_.IPAddress.AddressFamily.ToString()
+											Name = $_.Name
+											IpAddress = $_.IPAddress.ToString()
+											IpAddressFamily = $_.IPAddress.AddressFamily.ToString()
 											IPAddressProperties = $(
 												$IpAddressProperty = @{}
-												$_.IPAddressProperties |
-												Where-Object {
+												$_.IPAddressProperties | Where-Object {
 													-not [String]::IsNullOrEmpty($_.Name)
-												} |
-												ForEach-Object { 
-													$IpAddressProperty.Add($_.Name, $_.Value)
+												} | ForEach-Object { 
+													$IpAddressProperty += @{ $_.Name = $_.Value }
 												}
 												Write-Output $IpAddressProperty
 											)
@@ -1730,13 +1432,11 @@ function Find-SqlServerService {
 									}
 									ProtocolProperties = $(
 										$ProtocolProperty = @{}
-										$_.ProtocolProperties |
-										Where-Object { 
+										$_.ProtocolProperties | Where-Object { 
 											-not [String]::IsNullOrEmpty($_.Name) -and
 											$_.Name -ine 'Enabled' 
-										} |
-										ForEach-Object {
-											$ProtocolProperty.Add($_.Name, $_.Value)
+										} | ForEach-Object {
+											$ProtocolProperty += @{ $_.Name = $_.Value }
 										}
 										Write-Output $ProtocolProperty
 									)
@@ -1744,632 +1444,451 @@ function Find-SqlServerService {
 							}
 						}
 
+						# Determine an IP Address & port the SQL Server service is listening on (if TCP/IP enabled)
+						$ServiceProtocol | Where-Object { 
+							$_.Name -ieq 'tcp' -and
+							$_.IsEnabled -eq $true
+						} | ForEach-Object {
 
-						# Figure out the IP address and port that SQL Server is listening on
-						Set-SqlServerServiceIpAddress -SqlService $SqlService
+							# If listening on all IPs then get the "IPAll" port info
+							# Otherwise get port info for an IP that's enabled and active
 
+							if ($_.ProtocolProperties['ListenOnAllIPs'] -eq $true) {
+
+								$_.IPAddresses | Where-Object { $_.Name -ieq 'ipall' } | ForEach-Object {
+									$Port = $_.IPAddressProperties['TcpPort']
+									if (-not $Port) {
+										$Port = $_.IPAddressProperties['TcpDynamicPorts']
+										$IsDynamicPort = $true
+									} else {
+										$IsDynamicPort = $false
+									}
+								}
+
+							} else {
+
+								# Start with 127.0.0.1 first in case that's the only IP that's enabled
+								$_.IPAddresses | Where-Object {
+									$_.IPAddressProperties['Active'] -eq $true -and 
+									$_.IPAddressProperties['Enabled'] -eq $true -and
+									$_.IPAddressFamily -ieq 'InterNetwork' -and
+									$_.IPAddress -ieq '127.0.0.1'
+								} | Select-Object -First 1 | ForEach-Object {
+
+									$ServiceIpAddress = $_.IPAddress
+									$Port = $_.IPAddressProperties['TcpPort']
+
+									if (-not $Port) {
+										$Port = $_.IPAddressProperties['TcpDynamicPorts']
+										$IsDynamicPort = $true
+									} else {
+										$IsDynamicPort = $false
+									}
+								}
+
+								# Now try and see if there's a non-loopback IP enabled
+								$_.IPAddresses | Where-Object {
+									$_.IPAddressProperties['Active'] -eq $true -and 
+									$_.IPAddressProperties['Enabled'] -eq $true -and
+									$_.IPAddressFamily -ieq 'InterNetwork' -and
+									$_.IPAddress -ine '127.0.0.1'
+								} | Select-Object -First 1 | ForEach-Object {
+
+									$ServiceIpAddress = $_.IPAddress
+									$Port = $_.IPAddressProperties['TcpPort']
+
+									if (-not $Port) {
+										$Port = $_.IPAddressProperties['TcpDynamicPorts']
+										$IsDynamicPort = $true
+									} else {
+										$IsDynamicPort = $false
+									}
+								} 
+							}
+						}
 					}
 
 
 					# Get the Service Start Date (if it's got a Process ID greater than than 0)
 					if ($_.ProcessId -gt 0) {
 						try {
-							Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$($_.ProcessId)'" -Property CreationDate -ComputerName $IPAddress -ErrorAction Stop | 
-							ForEach-Object {
-								$SqlService.ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
+							Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$($_.ProcessId)'" -Property CreationDate -ComputerName $IpAddress -ErrorAction Stop | ForEach-Object {
+								$ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
 							}
 						}
 						catch {
-							$SqlService.ServiceStartDate = $null
+							$ServiceStartDate = $null
 						}
 					} else {
-						$SqlService.ServiceStartDate = $null
+						$ServiceStartDate = $null
 					}
 
-
-					# Finally, figure out the servername for this service
-					$SqlService.ServerName = Get-SqlServiceServername -SqlService $SqlService
-
-
-					Write-Output -InputObject $SqlService
-
-					# Add the service to the discovered service collection
-					$ServiceCollection += $SqlService.DisplayName
-
+					Write-Output (
+						New-Object -TypeName psobject -Property @{
+							ComputerName = $ComputerName
+							#ClusterName = $ClusterName
+							DisplayName = $_.DisplayName
+							Description = $_.Description
+							ComputerIpAddress = $IpAddress
+							#InstanceName = $InstanceName
+							IsNamedInstance = $IsNamedInstance
+							IsClusteredInstance = $IsClusteredInstance
+							IsDynamicPort = $IsDynamicPort
+							IsHadrEnabled = $_.IsHadrEnabled
+							PathName = $_.PathName
+							Port = $Port
+							ProcessId = $_.ProcessId
+							ServerName = $(
+								if ($IsNamedInstance -eq $true) {
+									if ($IsClusteredInstance -eq $true) {
+										[String]::Join('\', @($ClusterName, $InstanceName))
+									} else {
+										if (
+											$ServiceTypeName -ine 'SQL Server' -or
+											$(
+												$ServiceProtocol | Where-Object {
+													$_.Name -ine 'sm' -and
+													$_.IsEnabled -eq $true
+												}
+											)
+										) {
+											# Another protocol besides shared memory is enabled or the service isn't SQL Server\SQL Server Agent; use the FQDN
+											[String]::Join('\', @($ComputerName, $InstanceName))
+										} else {
+											# Shared memory is the only protocol enabled; use the NETBIOS name
+											[String]::Join('\', @($NetbiosComputerName, $InstanceName))
+										}
+									}
+								} else {
+									if ($IsClusteredInstance -eq $true) {
+										$ClusterName
+									} else {
+										if (
+											$ServiceTypeName -ine 'SQL Server' -or
+											$(
+												$ServiceProtocol | Where-Object {
+													$_.Name -ine 'sm' -and
+													$_.IsEnabled -eq $true
+												}
+											)
+										) {
+											# Another protocol besides shared memory is enabled or the service isn't SQL Server\SQL Server Agent; use the FQDN
+											$ComputerName
+										} else {
+											# Shared memory is the only protocol enabled; use the NETBIOS name
+											$NetbiosComputerName
+										}
+									}
+								}
+							)
+							ServiceIpAddress = $ServiceIpAddress
+							ServiceProtocols = $ServiceProtocol
+							ServiceStartDate = $ServiceStartDate
+							ServiceState = $_.ServiceState.ToString()
+							#ServiceType = $_.Type.ToString()
+							ServiceTypeName = $ServiceTypeName
+							ServiceAccount = $_.ServiceAccount
+							StartMode = $_.StartMode.ToString()
+							StartupParameters = $_.StartupParameters
+						}
+					)
 				} 
 			}
 			catch {
 
 				# If we get this error it's possible that this is a SQL 2000 server in which case we need to look at the registry to find installed services
-				if ($_.Exception.Message -inotlike '*SQL Server WMI provider is not available*') {
-					# Something else has happened; Let the error bubble up
-					throw
-				}
-			}
-			#endregion
+				if ($_.Exception.Message -ilike '*SQL Server WMI provider is not available*') {
+					try {
 
+						# Use the WMI Registry provider to access the registry on $ComputerName
+						# For info on using this WMI class see http://msdn.microsoft.com/en-us/library/windows/desktop/aa393664(v=vs.85).aspx
+						$StdRegProv = Get-WmiObject -Namespace root\DEFAULT -Query "select * FROM meta_class WHERE __Class = 'StdRegProv'" -ComputerName $ComputerName -ErrorAction Stop
 
-			#region SQL Server Services (WMI & registry)
+						# Iterate through installed instances of the Database Engine (which includes the SQL Agent)
+						$($StdRegProv.GetMultiStringValue($HKEY_LOCAL_MACHINE,'SOFTWARE\Microsoft\Microsoft SQL Server','InstalledInstances')).sValue | ForEach-Object {
 
-			# Now look through the machine's registry for instances that were not found by the ManagedComputer object
-			# This can happen for a few reasons:
-			#   - Using a lower version of SMO on the machine where the script is running than the version of SQL Server on the target server
-			#   - The target server is running one or more SQL 2000 instances
-			# This is not the preferred way to get service information because it assumes things about registry paths...but it's better than nothing
-			try {
-
-				$SqlServiceBase = Get-SqlServiceObject
-				$SqlServiceBase.ComputerName = $ComputerName
-				$SqlServiceBase.ComputerIpAddress = $IPAddress
-				$SqlServiceBase.IsHadrEnabled = $null
-				$SqlServiceBase.ServiceIpAddress = $null
-				$SqlServiceBase.ServiceProtocols = $null
-				$SqlServiceBase.Version = $null
-
-
-				# Use the WMI Registry provider to access the registry on $ComputerName
-				# For info on using this WMI class see http://msdn.microsoft.com/en-us/library/windows/desktop/aa393664(v=vs.85).aspx
-				$StdRegProv = Get-WmiObject -Namespace root\DEFAULT -Query "select * FROM meta_class WHERE __Class = 'StdRegProv'" -ComputerName $ComputerName -ErrorAction Stop
-
-
-				# Check if there's a Wow6432Node node in the registry. Use this later for determining 32-bit vs 64-bit versions of SQL Server
-				# Return code of 0 means it DOES exist
-				if (($StdRegProv.EnumKey($HKEY_LOCAL_MACHINE,'SOFTWARE\Wow6432Node\Microsoft\Microsoft SQL Server')).ReturnValue -eq 0) {
-					$HasWow6432Node = $true
-				} else {
-					$HasWow6432Node = $false
-				}
-
-
-				# Let's use WMI and the registry to gather service information
-				# A few rules:
-				# - There can only be one instance of SQL Browser and Integration Services in 2005 and higher (and it cannot be a named instance)
-				# - There can be only one instance of Analysis Services, Reporting Services, or Microsoft Search in 2000 (and it cannot be a named instance)
-				# - There can be multiple instances of Analysis Services, Reporting Services, and Fulltext Services in 2005 and higher
-				# - Only SSAS in SQL 2012 and higher can be clustered
-                
-				$IncludeService = @(
-					'(DisplayName="MSSQLSERVER")',
-					'(DisplayName LIKE "MSSQL$%")',
-					'(DisplayName="SQLSERVERAGENT")',
-					'(DisplayName LIKE "SQLAgent$%")',
-					'(DisplayName="MSSQLServerOLAPService")',
-					'(DisplayName="Microsoft Search")',
-					'(DisplayName="ReportServer")',
-					'(DisplayName="SQL Server Browser")',
-					'(DisplayName LIKE "NS$%")',
-					'(DisplayName LIKE "SQL Server Integration Services%")',
-					'(DisplayName LIKE "SQL Server (%)")',
-					'(DisplayName LIKE "SQL Server Agent (%)")',
-					'(DisplayName LIKE "SQL Server Analysis Services (%)")',
-					'(DisplayName LIKE "SQL Server FullText Search (%)")',
-					'(DisplayName LIKE "SQL Full-text Filter Daemon Launcher (%)")',
-					'(DisplayName LIKE "SQL Server Reporting Services (%)")'
-				) -join ' OR '
-
-				# Build the WMI filter parameter based on services to find and services already found
-				if ([String]::IsNullOrEmpty($ServiceCollection) -eq $true) {
-					$ServiceFilter = $IncludeService
-				} else {
-					$ExcludeService = $($ServiceCollection | ForEach-Object { 'DisplayName != "{0}"' -f $_ }) -join ' AND '
-					$ServiceFilter = '({0}) AND ({1})' -f $IncludeService, $ExcludeService
-				}
-
-				Get-WmiObject -Namespace root\CIMV2 -Class Win32_Service -Filter $ServiceFilter -Property $ServicePropertyList -ComputerName $IPAddress -ErrorAction Stop | 
-				ForEach-Object {
-
-					# Copy the base object first
-					$SqlService = $SqlServiceBase.psobject.Copy()
-
-					$SqlService.ServerName = $ComputerName
-					$SqlService.DisplayName = $_.DisplayName
-					$SqlService.PathName = $_.PathName
-					$SqlService.StartMode = $_.StartMode
-					$SqlService.ProcessId = $_.ProcessId
-					$SqlService.ServiceState = $_.State
-					$SqlService.ServiceAccount = $_.StartName
-					$SqlService.Description = $_.Description
-
-					<# Assume the instance is not clustered. We'll figure this out for sure in just a bit #>
-					$SqlService.IsClusteredInstance = $false
-					$SqlService.VirtualServerName = [String]::Empty
-
-
-					# Build registry key paths for the instance
-					if (($_.Name).IndexOf('$') -gt 0) {
-						$SqlService.InstanceName = ($_.Name).Substring(($_.Name).IndexOf('$') + 1)
-						$SqlService.IsNamedInstance = $true
-						$RegistryKeyInstanceSubkey = 'Microsoft SQL Server\{0}' -f $SqlService.InstanceName
-					} else {
-						$SqlService.InstanceName = 'MSSQLSERVER'
-						$SqlService.IsNamedInstance = $false
-						$RegistryKeyInstanceSubkey = 'MSSQLServer' -f $SqlService.InstanceName
-					}
-					$RegistryKeySoftwareRoot = 'SOFTWARE'
-					$RegistryKeyInstanceNameRoot = '{0}\Microsoft\{1}' -f $RegistryKeySoftwareRoot, $RegistryKeyInstanceSubkey
-
-
-					# Get the Friendly name for the service based on the service name
-					$SqlService.ServiceTypeName = switch -Wildcard ($_.Name) {
-						'MSSQLSERVER' { 'SQL Server' }
-						'MSSQL$*' { 'SQL Server' }
-						'SQLSERVERAGENT' { 'SQL Server Agent' }
-						'SQLAgent$*' { 'SQL Server Agent' }
-						'MSSEARCH' { 'Microsoft Search service' }
-						'msftesql' { 'SQL Server FullText Search' }
-						'msftesql$*' { 'SQL Server FullText Search' }
-						'MsDtsServer*' { 'SQL Server Integration Services' }
-						'MSSQLServerOLAPService' { 'SQL Server Analysis Services' }
-						'MSOLAP$*' { 'SQL Server Analysis Services' }
-						'ReportServer' { 'SQL Server Reporting Services' }
-						'ReportServer$*' { 'SQL Server Reporting Services' }
-						'SQLBrowser' { 'SQL Server Browser' }
-						'NS$*' { 'SQL Server Notification Services' }
-						'MSSQLFDLauncher' { 'SQL Full-text Filter Daemon Launcher' }
-						'MSSQLFDLauncher$*' { 'SQL Full-text Filter Daemon Launcher' }
-						default { 'Unknown' }
-					}
-
-
-					# Set defaults that apply to all services
-					$SqlService.IsDynamicPort = $null
-					$SqlService.Port = $null
-					$SqlService.ServerName = $ComputerName
-
-					<# Gather details specific to SQL Server service #>
-					if ($SqlService.ServiceTypeName -ieq 'SQL Server') {
-                        
-						if ($SqlService.DisplayName -ieq 'MSSQLSERVER' -or $SqlService.DisplayName -ilike 'MSSQL$*') {
-                            
-							# This condition means <= SQL 2000
-
-							# Determine if this is a clustered server (and the FQDN if it is)
-							# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-							$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\Cluster", 'ClusterName')).sValue
-
-							if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-								$SqlService.IsClusteredInstance = $true
-								$SqlService.ServiceIpAddress = $null
-
-								try {
-									if ([String]::IsNullOrEmpty($DomainName)) {
-										Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-										ForEach-Object {
-											$DomainName = $_.Domain
-										}
-									}
-									$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
-								}
-								catch {
-									# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-									$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\Cluster", 'ClusterName')).sValue
-								}
-
+							if ($_ -ine 'MSSQLSERVER') {
+								$InstanceName = $_
+								$DisplayName = "MSSQL`$$InstanceName"
+								$IsNamedInstance = $true
+								$RegistryKeyRootPath = "SOFTWARE\Microsoft\Microsoft SQL Server\$($_)"
 							} else {
-								$SqlService.IsClusteredInstance = $false
-								$SqlService.VirtualServerName = [String]::Empty
-								$SqlService.ServiceIpAddress = $IPAddress
+								$InstanceName = $null
+								$DisplayName = 'MSSQLSERVER'
+								$IsNamedInstance = $false
+								$RegistryKeyRootPath = 'SOFTWARE\Microsoft\MSSQLServer'
 							}
 
+							# Determine if instance is clustered
+							$IsClusteredInstance = $null
+							$ClusterName = [String]::Empty
 
-							$SqlService.Edition = $null # Not exposed in SQL 2000
-							$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\MSSQLServer\CurrentVersion", 'CurrentVersion')).sValue
-							$SqlService.ServicePackLevel = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\MSSQLServer\CurrentVersion", 'CSDVersion')).sValue
-
-							# Get the TCP port number for SQL Server Services
-							$SqlService.Port = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\MSSQLServer\SuperSocketNetLib\Tcp",'TcpDynamicPorts')).sValue
-							if (-not $SqlService.Port) {
-								$SqlService.Port = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\MSSQLServer\SuperSocketNetLib\Tcp",'TcpPort')).sValue
-								$SqlService.IsDynamicPort = $false
-							} else {
-								$SqlService.IsDynamicPort = $true
-							}
-
-
-							# Gather protocol details
-							$SqlService.ServiceProtocols = $($StdRegProv.GetMultiStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\MSSQLServer\SuperSocketNetLib",'ProtocolList')).sValue | 
-							ForEach-Object {                                
-								New-Object -TypeName PSObject -Property @{
-									Name               = $_
-									DisplayName        = switch ($_) {
-										'adsp' { 'Apple Talk' }
-										'bv' { 'Banyan Vines' }
-										'np' { 'Named Pipes' }
-										'rpc' { 'Multiprotocol' }
-										'spx' { 'NWLink IPX/SPX' }
-										'tcp' { 'TCP/IP' }
-										'via' { 'VIA' }
-										default { $_ }
-									}
-									IsEnabled          = $true
-									ProtocolProperties = Get-RegistryKeyValueEnum -StdRegProv $StdRegProv -RootKey $HKEY_LOCAL_MACHINE -SubKey "$RegistryKeyInstanceNameRoot\MSSQLServer\SuperSocketNetLib\$_"
-								}                                
-							}
-
-
-							# If $ComputerName is the local host then use the loopback IP for connectivity, otherwise use $IpAddress
+							# If $ComputerName is the local host then use the loopback IP, otherwise use $IpAddress
 							if (
 								$ComputerName -ieq $env:COMPUTERNAME -or
 								$ComputerName.StartsWith([String]::Concat($env:COMPUTERNAME, '.'), [System.StringComparison]::InvariantCultureIgnoreCase)
 							) {
-								$SqlServiceBase.ServiceIpAddress = '127.0.0.1'
+								$ServiceIpAddress = '127.0.0.1'
 							} else {
-								$SqlServiceBase.ServiceIpAddress = $IPAddress
+								$ServiceIpAddress = $IpAddress
 							}
 
 
-						} else {
-
-							# This condition means >= SQL 2005
-
-							# Figure out where to get instance details from the registry
-							$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\SQL", $SqlService.InstanceName)).sValue
-							if ([String]::IsNullOrEmpty($InstanceId)) {
-								$RegistryKeySoftwareRoot = 'SOFTWARE\Wow6432Node'
-								$RegistryKeyInstanceNameRoot = '{0}\Microsoft\{1}' -f $RegistryKeySoftwareRoot, $RegistryKeyInstanceSubkey
-								$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\SQL", $SqlService.InstanceName)).sValue
-								$EditionDescriptor = [String]::Empty
+							# Get the TCP port number for SQL Server Services
+							$Port = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyRootPath\MSSQLServer\SuperSocketNetLib\Tcp",'TcpDynamicPorts')).sValue
+							if (-not $Port) {
+								$Port = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyRootPath\MSSQLServer\SuperSocketNetLib\Tcp",'TcpPort')).sValue
+								$IsDynamicPort = $false
 							} else {
-								# If there's a Wow6432Node in the registry then this instance is 64-bit; If not then it's 32-bit
-								if ($HasWow6432Node -eq $true) {
-									$EditionDescriptor = ' (64-bit)'
-								} else {
-									$EditionDescriptor = [String]::Empty
-								}
+								$IsDynamicPort = $true
 							}
-							$RegistryKeyInstanceIdRoot = '{0}\Microsoft\Microsoft SQL Server\{1}' -f $RegistryKeySoftwareRoot, $InstanceId
 
+							# Get Service Information
+							Get-WmiObject -Namespace root\CIMV2 -Class Win32_Service `
+							-Filter $('DisplayName = "{0}" OR DisplayName = "SQL Server ({0})"' -f $DisplayName) `
+							-Property PathName,StartMode,ProcessId,State,StartName,Description -ComputerName $IpAddress -ErrorAction Stop | 
+							ForEach-Object {
+								$PathName = $_.PathName
+								$StartMode = $_.StartMode
+								$ProcessId = $_.ProcessId
+								$ServiceState = $_.State
+								$ServiceAccount = $_.StartName
+								$Description = $_.Description
+							}
 
-							# Determine if this is a clustered server (and the FQDN if it is)
-							# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-							# ...because you can get into some complicated scenarios with multi-subnet clusters that are best left to letting the client resolve
-							$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-								$SqlService.IsClusteredInstance = $true
-								$SqlService.ServiceIpAddress = $null
-
+							# Get the Service Start Date (if it's got a Process ID greater than than 0)
+							if ($ProcessId -gt 0) {
 								try {
-									if ([String]::IsNullOrEmpty($DomainName)) {
-										Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-										ForEach-Object {
-											$DomainName = $_.Domain
-										}
+									Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$ProcessId'" -Property CreationDate -ComputerName $IpAddress -ErrorAction Stop | ForEach-Object {
+										$ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
 									}
-									$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
 								}
 								catch {
-									# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-									$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
+									$ServiceStartDate = $null
 								}
-
 							} else {
-								$SqlService.IsClusteredInstance = $false
-								$SqlService.VirtualServerName = [String]::Empty
+								$ServiceStartDate = $null
 							}
 
 
+							# Startup Parameters
+							$RegistryKeyPath = "$RegistryKeyRootPath\MSSQLServer\Parameters"
+							$Parameters = $StdRegProv.EnumValues($HKEY_LOCAL_MACHINE,$RegistryKeyPath)
+							$StartupParameters = @()
 
-							# Get other details from registry
-							$SqlService.IsHadrEnabled = switch (($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\MSSQLServer\HADR", 'HADR_Enabled')).uValue) {
-								0 { $false }
-								1 { $true }
-								default { $null }
-							}
-							$SqlService.Edition = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Edition')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.Edition) -and $SqlService.Edition.IndexOf($EditionDescriptor) -lt 0) {
-								$SqlService.Edition = '{0}{1}' -f $SqlService.Edition, $EditionDescriptor
-							}
-							$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Version')).sValue
-							$SqlService.ServicePackLevel = ($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'SP')).uValue
-
-
-							# Gather protocol details
-							# 3 protocols for SQL 2005 and up: Shared Memory, Named Pipes, & TCP/IP (although Via is in the registry if you care to look for yourself)
-							$SqlService.ServiceProtocols = $(
-
-								# Named Pipes
-								New-Object -TypeName PSObject -Property @{
-									Name               = 'Np'
-									DisplayName        = 'Named Pipes'
-									IsEnabled          = [Boolean]($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Np", 'Enabled')).uValue
-									IPAddresses        = $null
-									ProtocolProperties = Get-RegistryKeyValueEnum -StdRegProv $StdRegProv `
-									-RootKey $HKEY_LOCAL_MACHINE `
-									-SubKey "$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Np" `
-									-Exclude DisplayName,Enabled
+							for ($i = 0; $i -lt ($Parameters.sNames | Measure-Object).Count; $i++) {
+								switch ($Parameters.Types[$i]) {
+									1 {
+										# REG_SZ
+										$StartupParameters += $($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,$RegistryKeyPath,"$($Parameters.sNames[$i])")).sValue
+									}
+									2 { 
+										# REG_EXPAND_SZ
+										$StartupParameters += $($StdRegProv.GetExpandedStringValue($HKEY_LOCAL_MACHINE,$RegistryKeyPath,"$($Parameters.sNames[$i])")).sValue
+									}
+									3 {
+										# REG_BINARY
+										$StartupParameters += [System.BitConverter]::ToString($($StdRegProv.GetBinaryValue($HKEY_LOCAL_MACHINE,$RegistryKeyPath,"$($Parameters.sNames[$i])").uValue) )
+									}
+									4 {
+										# REG_DWORD
+										$StartupParameters += $($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,$RegistryKeyPath, "$($Parameters.sNames[$i])")).uValue
+									}
+									7 {
+										# REG_MULTI_SZ
+										$($StdRegProv.GetMultiStringValue($HKEY_LOCAL_MACHINE,$RegistryKeyPath,"$($Parameters.sNames[$i])")).sValue | ForEach-Object {
+											$StartupParameters += $_
+										} 
+									}
+									default { $null }
 								}
+							} 
 
-								# Shared Memory
-								New-Object -TypeName PSObject -Property @{
-									Name               = 'Sm'
-									DisplayName        = 'Shared Memory'
-									IsEnabled          = [Boolean]($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Sm", 'Enabled')).uValue
-									IPAddresses        = $null
-									ProtocolProperties = @{}
-								}
-
-								# TCP/IP
-								New-Object -TypeName PSObject -Property @{
-									Name               = 'Tcp'
-									DisplayName        = 'TCP/IP'
-									IsEnabled          = [Boolean]($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Tcp", 'Enabled')).uValue
-									IPAddresses        = $(
-										($StdRegProv.EnumKey($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Tcp")).sNames | 
-										Where-Object {
-											$_ -match '^IP(\d{1}|All)$'
-										} |
-										ForEach-Object {
-											New-Object -TypeName PSObject -Property @{
-												Name                = $_
-												IPAddressProperties = Get-RegistryKeyValueEnum -StdRegProv $StdRegProv `
-												-RootKey $HKEY_LOCAL_MACHINE `
-												-SubKey "$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Tcp\$_" `
-												-Exclude DisplayName,Enabled
-											} |
-											Select-Object -Property Name, IPAddressProperties, @{
-												Name       = 'IpAddress'
-												Expression = {
-													if ([String]::IsNullOrEmpty($_.IPAddressProperties['IpAddress'])) {
-														'0.0.0.0'
-													} else {
-														$_.IPAddressProperties.IpAddress
-													}
-												}
-											} | 
-											Select-Object -Property Name, IpAddress, IPAddressProperties, @{
-												Name       = 'IpAddressFamily'
-												Expression = {
-													([System.Net.IPAddress]$_.IpAddress).AddressFamily
-												}
+							Write-Output (
+								New-Object -TypeName psobject -Property @{
+									ComputerName = $ComputerName
+									DisplayName = $DisplayName
+									Description = $Description
+									ComputerIpAddress = $IpAddress
+									IsNamedInstance = $IsNamedInstance
+									IsClusteredInstance = $IsClusteredInstance
+									IsDynamicPort = $IsDynamicPort
+									IsHadrEnabled = $null # Not applicable to SQL 2000
+									PathName = $PathName
+									Port = $Port
+									ProcessId = $ProcessId
+									ServerName = $(
+										if ($IsNamedInstance -eq $true) {
+											if ($IsClusteredInstance -eq $true) {
+												[String]::Join('\', @($ClusterName, $InstanceName))
+											} else {
+												[String]::Join('\', @($ComputerName, $InstanceName))
+											}
+										} else {
+											if ($IsClusteredInstance -eq $true) {
+												$ClusterName
+											} else {
+												$ComputerName
 											}
 										}
 									)
-									ProtocolProperties = Get-RegistryKeyValueEnum -StdRegProv $StdRegProv `
-									-RootKey $HKEY_LOCAL_MACHINE `
-									-SubKey "$RegistryKeyInstanceIdRoot\MSSQLServer\SuperSocketNetLib\Tcp\" `
-									-Exclude DisplayName,Enabled
+									ServiceIpAddress = $ServiceIpAddress
+									ServiceProtocols = $null # TODO: Gather protocol information from registry
+									ServiceStartDate = $ServiceStartDate
+									ServiceState = $ServiceState
+									ServiceTypeName = 'SQL Server'
+									ServiceAccount = $ServiceAccount
+									StartMode = $StartMode
+									StartupParameters = [String]::Join(';', $StartupParameters)
 								}
 							)
 
 
-							# Figure out the IP address and port that SQL Server is listening on
-							Set-SqlServerServiceIpAddress -SqlService $SqlService
 
-						}
-
-						# Get startup parameters
-						$SqlService.StartupParameters = $(
-							(Get-RegistryKeyValueEnum -StdRegProv $StdRegProv `
-								-RootKey $HKEY_LOCAL_MACHINE `
-								-SubKey "$RegistryKeyInstanceIdRoot\MSSQLServer\Parameters"
-							).Values | Sort-Object
-						) -join ';'
-					}
-
-
-					<# Gather details specific to SQL Server Agent service #>
-					if ($SqlService.ServiceTypeName -ieq 'SQL Server Agent') {
-						if ($SqlService.DisplayName -ieq 'SQLSERVERAGENT' -or $SqlService.DisplayName -ilike 'SQLAgent$*') {
-
-							# Determine if this is a clustered server (and the FQDN if it is)
-							# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-							$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\Cluster", 'ClusterName')).sValue
-
-							if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-								$SqlService.IsClusteredInstance = $true
-								$SqlService.ServiceIpAddress = $null
-
-								try {
-									if ([String]::IsNullOrEmpty($DomainName)) {
-										Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-										ForEach-Object {
-											$DomainName = $_.Domain
-										}
-									}
-									$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
-								}
-								catch {
-									# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-									$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceNameRoot\Cluster", 'ClusterName')).sValue
-								}
-
+							# Now let's tackle the SQL Agent. A lot of the information is the same as the SQL Server Service
+							if ($IsNamedInstance) {
+								$DisplayName = "SQLAgent`$$InstanceName"
 							} else {
-								$SqlService.IsClusteredInstance = $false
-								$SqlService.VirtualServerName = [String]::Empty
+								$DisplayName = 'SQLSERVERAGENT'
 							}
 
-						} else {
-
-							# Figure out where to get instance details from the registry
-							$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\SQL", $SqlService.InstanceName)).sValue
-							if ([String]::IsNullOrEmpty($InstanceId)) {
-								$RegistryKeySoftwareRoot = 'SOFTWARE\Wow6432Node'
-								$RegistryKeyInstanceNameRoot = '{0}\Microsoft\{1}' -f $RegistryKeySoftwareRoot, $RegistryKeyInstanceSubkey
-								$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\SQL", $SqlService.InstanceName)).sValue
-								$EditionDescriptor = [String]::Empty
-							} else {
-								# If there's a Wow6432Node in the registry then this instance is 64-bit; If not then it's 32-bit
-								if ($HasWow6432Node -eq $true) {
-									$EditionDescriptor = ' (64-bit)'
-								} else {
-									$EditionDescriptor = [String]::Empty
-								}
-							}
-							$RegistryKeyInstanceIdRoot = '{0}\Microsoft\Microsoft SQL Server\{1}' -f $RegistryKeySoftwareRoot, $InstanceId
-
-
-							# Determine if this is a clustered server (and the FQDN if it is)
-							# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-							# ...because you can get into some complicated scenarios with multi-subnet clusters that are best left to letting the client resolve
-							$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-								$SqlService.IsClusteredInstance = $true
-								$SqlService.ServiceIpAddress = $null
-
-								try {
-									if ([String]::IsNullOrEmpty($DomainName)) {
-										Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-										ForEach-Object {
-											$DomainName = $_.Domain
-										}
-									}
-									$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
-								}
-								catch {
-									# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-									$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
-								}
-
-							} else {
-								$SqlService.IsClusteredInstance = $false
-								$SqlService.VirtualServerName = [String]::Empty
-							}
-
-						}
-					}
-
-
-					<# Gather details specific to SSAS service #>
-					if ($SqlService.ServiceTypeName -ieq 'SQL Server Analysis Services') {
-						if ($SqlService.DisplayName -ieq 'MSSQLServerOLAPService') {
-							## These are not the right registry locations for SQL 2000 - verified in a VM with only SSAS installed. Are they available somewhere else?
-							#$SqlService.Edition = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\MSSQLServer\MSSQLServer\Setup", 'Edition')).sValue
-							#$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\MSSQLServer\MSSQLServer\CurrentVersion", 'CurrentVersion')).sValue
-							#$SqlService.ServicePackLevel = ($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\OLAP Server\CurrentVersion", 'CSDVersion')).uValue
-
-							$SqlService.Edition = $null
-							$SqlService.Version = $null
-							$SqlService.ServicePackLevel = $null
-
-						} else {
-
-							# Figure out where to get instance details from the registry
-							$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\OLAP", $SqlService.InstanceName)).sValue
-							if ([String]::IsNullOrEmpty($InstanceId)) {
-								$RegistryKeySoftwareRoot = 'SOFTWARE\Wow6432Node'
-								$RegistryKeyInstanceNameRoot = '{0}\Microsoft\{1}' -f $RegistryKeySoftwareRoot, $RegistryKeyInstanceSubkey
-								$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\OLAP", $SqlService.InstanceName)).sValue
-								$EditionDescriptor = [String]::Empty
-							} else {
-								# If there's a Wow6432Node in the registry then this instance is 64-bit; If not then it's 32-bit
-								if ($HasWow6432Node -eq $true) {
-									$EditionDescriptor = ' (64-bit)'
-								} else {
-									$EditionDescriptor = [String]::Empty
-								}
-							}
-							$RegistryKeyInstanceIdRoot = '{0}\Microsoft\Microsoft SQL Server\{1}' -f $RegistryKeySoftwareRoot, $InstanceId
-
-
-							# Determine if this is a clustered server (and the FQDN if it is)
-							# If it is a clustered instance don't worry about resolving the service IP address - let the client making the connection handle that
-							# ...because you can get into some complicated scenarios with multi-subnet clusters that are best left to letting the client resolve
-							$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.VirtualServerName)) {
-								$SqlService.IsClusteredInstance = $true
-								$SqlService.ServiceIpAddress = $null
-
-								try {
-									if ([String]::IsNullOrEmpty($DomainName)) {
-										Get-WmiObject -Namespace root\CIMV2 -Class Win32_ComputerSystem -Property Domain -ComputerName $IPAddress -ErrorAction Stop | 
-										ForEach-Object {
-											$DomainName = $_.Domain
-										}
-									}
-									$SqlService.VirtualServerName = [String]::Join('.', @($SqlService.VirtualServerName, $DomainName)).ToUpper()
-								}
-								catch {
-									# Unable to resolve the domain name for the clustered service so just use the virtual server name from the registry
-									$SqlService.VirtualServerName = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Cluster", 'ClusterName')).sValue
-								}
-
-							} else {
-								$SqlService.IsClusteredInstance = $false
-								$SqlService.VirtualServerName = [String]::Empty
-							}
-
-
-							$SqlService.Edition = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Edition')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.Edition) -and $SqlService.Edition.IndexOf($EditionDescriptor) -lt 0) {
-								$SqlService.Edition = '{0}{1}' -f $SqlService.Edition, $EditionDescriptor
-							}
-							$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Version')).sValue
-							$SqlService.ServicePackLevel = ($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'SP')).uValue
-						}
-					}
-
-
-					<# Gather details specific to Reporting Services service #>
-					if ($SqlService.ServiceTypeName -ieq 'SQL Server Reporting Services') {
-						if ($SqlService.DisplayName -ieq 'ReportServer') {
-							$SqlService.Edition = switch (($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\MSSQLServer\MSSQLServer\Setup", 'Edition')).sValue) {
-								'{2879CA50-1599-4F4B-B9EC-1110C1094C16}' { 'Developer Edition' }
-								'{B19FEFE7-069D-4FC4-8FDF-19661EAB6CE4}' { 'Standard Edition' }
-								'{7C93251A-BFB4-4EB8-A57C-81B875BB12E4}' { 'Evaluation Edition' }
-								'{33FE9EED-1976-4A51-A7AF-332D9BBB9400}' { 'Enterprise Edition' }
-							}
-							$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\MSSQLServer\MSSQLServer\CurrentVersion", 'CurrentVersion')).sValue
-						} else {
-
-							# Figure out where to get instance details from the registry
-							$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\RS", $SqlService.InstanceName)).sValue
-							if ([String]::IsNullOrEmpty($InstanceId)) {
-								$RegistryKeySoftwareRoot = 'SOFTWARE\Wow6432Node'
-								$RegistryKeyInstanceNameRoot = '{0}\Microsoft\{1}' -f $RegistryKeySoftwareRoot, $RegistryKeyInstanceSubkey
-								$InstanceId = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeySoftwareRoot\Microsoft\Microsoft SQL Server\Instance Names\RS", $SqlService.InstanceName)).sValue
-								$EditionDescriptor = [String]::Empty
-							} else {
-								# If there's a Wow6432Node in the registry then this instance is 64-bit; If not then it's 32-bit
-								if ($HasWow6432Node -eq $true) {
-									$EditionDescriptor = ' (64-bit)'
-								} else {
-									$EditionDescriptor = [String]::Empty
-								}
-							}
-							$RegistryKeyInstanceIdRoot = '{0}\Microsoft\Microsoft SQL Server\{1}' -f $RegistryKeySoftwareRoot, $InstanceId
-
-							$SqlService.Edition = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Edition')).sValue
-							if (-not [String]::IsNullOrEmpty($SqlService.Edition) -and $SqlService.Edition.IndexOf($EditionDescriptor) -lt 0) {
-								$SqlService.Edition = '{0}{1}' -f $SqlService.Edition, $EditionDescriptor
-							}
-							$SqlService.Version = ($StdRegProv.GetStringValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'Version')).sValue
-							$SqlService.ServicePackLevel = ($StdRegProv.GetDWORDValue($HKEY_LOCAL_MACHINE,"$RegistryKeyInstanceIdRoot\Setup", 'SP')).uValue
-						}
-					}
-
-
-
-					# Get the Service Start Date (if it's got a Process ID greater than than 0)
-					if ($SqlService.ProcessId -gt 0) {
-						try {
-							Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$($SqlService.ProcessId)'" -Property CreationDate -ComputerName $IPAddress -ErrorAction Stop | 
+							# Get Service Information
+							Get-WmiObject -Namespace root\CIMV2 -Class Win32_Service `
+							-Filter $('DisplayName = "{0}" OR DisplayName = "SQL Server Agent ({0})"' -f $DisplayName) `
+							-Property PathName,StartMode,ProcessId,State,StartName,Description -ComputerName $IpAddress -ErrorAction Stop | 
 							ForEach-Object {
-								$SqlService.ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
+								$PathName = $_.PathName
+								$StartMode = $_.StartMode
+								$ProcessId = $_.ProcessId
+								$ServiceState = $_.State
+								$ServiceAccount = $_.StartName
+								$Description = $_.Description
 							}
+
+							# Get the Service Start Date (if it's got a Process ID greater than than 0)
+							if ($ProcessId -gt 0) {
+								try {
+									Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$ProcessId'" -Property CreationDate -ComputerName $IpAddress -ErrorAction Stop | ForEach-Object {
+										$ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
+									}
+								}
+								catch {
+									$ServiceStartDate = $null
+								}
+							} else {
+								$ServiceStartDate = $null
+							}
+
+							Write-Output (
+								New-Object -TypeName psobject -Property @{
+									ComputerName = $ComputerName
+									DisplayName = $DisplayName
+									Description = $Description
+									ComputerIpAddress = $IpAddress
+									IsNamedInstance = $IsNamedInstance
+									IsClusteredInstance = $IsClusteredInstance
+									IsDynamicPort = $IsDynamicPort
+									IsHadrEnabled = $null # Not applicable to SQL 2000
+									PathName = $PathName
+									Port = $null
+									ProcessId = $ProcessId
+									ServerName = $(
+										if ($IsNamedInstance -eq $true) {
+											if ($IsClusteredInstance -eq $true) {
+												[String]::Join('\', @($ClusterName, $InstanceName))
+											} else {
+												[String]::Join('\', @($ComputerName, $InstanceName))
+											}
+										} else {
+											if ($IsClusteredInstance -eq $true) {
+												$ClusterName
+											} else {
+												$ComputerName
+											}
+										}
+									)
+									ServiceIpAddress = $ServiceIpAddress
+									ServiceStartDate = $ServiceStartDate
+									ServiceState = $ServiceState
+									ServiceTypeName = 'SQL Server Agent'
+									ServiceAccount = $ServiceAccount
+									StartMode = $StartMode
+									StartupParameters = $null
+								}
+							)
 						}
-						catch {
-							$SqlService.ServiceStartDate = $null
-						}
-					} else {
-						$SqlService.ServiceStartDate = $null
+
+						# Now let's test for Analysis Services, Reporting Services, and Microsoft Search. 
+						# You can't have more than one instance of each in 2000
+						Get-WmiObject -Namespace root\CIMV2 -Class Win32_Service `
+						-Filter "(DisplayName = 'MSSQLServerOLAPService') or (DisplayName = 'Microsoft Search') or (DisplayName = 'ReportServer')" `
+						-Property DisplayName,PathName,StartMode,ProcessId,State,StartName,Description -ComputerName $IpAddress -ErrorAction Stop | 
+						ForEach-Object {
+
+							$DisplayName = $_.DisplayName
+							$PathName = $_.PathName
+							$StartMode = $_.StartMode
+							$ProcessId = $_.ProcessId
+							$ServiceState = $_.State
+							$ServiceAccount = $_.StartName
+							$Description = $_.Description
+
+							# Get the Service Start Date (if it's got a Process ID greater than than 0)
+							if ($ProcessId -gt 0) {
+								try {
+									Get-WmiObject -Namespace root\CIMV2 -Class Win32_Process -Filter "ProcessId = '$ProcessId'" -Property CreationDate -ComputerName $IpAddress -ErrorAction Stop | ForEach-Object {
+										$ServiceStartDate = $_.ConvertToDateTime($_.CreationDate)
+									}
+								}
+								catch {
+									$ServiceStartDate = $null
+								}
+							} else {
+								$ServiceStartDate = $null
+							}
+
+							Write-Output (
+								New-Object -TypeName psobject -Property @{
+									ComputerName = $ComputerName
+									DisplayName = $DisplayName
+									Description = $Description
+									ComputerIpAddress = $IpAddress
+									IsNamedInstance = $false # Can't have named instances of SSAS, SSRS, or Microsoft Search in SQL 2000
+									IsClusteredInstance = $false # Can't cluster SSAS, SSRS, or Microsoft Search in SQL 2000
+									IsDynamicPort = $null
+									IsHadrEnabled = $null # Not applicable to SQL 2000
+									PathName = $PathName
+									Port = $null
+									ProcessId = $ProcessId
+									ServerName = $ComputerName
+									ServiceIpAddress = $IpAddress
+									ServiceStartDate = $ServiceStartDate
+									ServiceState = $ServiceState
+									ServiceTypeName = switch ($DisplayName) {
+										'Microsoft Search' { 'Microsoft Search service' } 
+										'MSSQLServerOLAPService' { 'SQL Server Analysis Services' }
+										'ReportServer' { 'SQL Server Reporting Services' }
+										default { 'Unknown' }
+									}
+									ServiceAccount = $ServiceAccount
+									StartMode = $StartMode
+									StartupParameters = $null
+								}
+							)
+						} 
+
 					}
-
-
-					# Finally, figure out the servername for this service
-					$SqlService.ServerName = Get-SqlServiceServername -SqlService $SqlService
-
-					Write-Output -InputObject $SqlService
-
+					catch {
+						throw
+					}
 				}
-				#endregion
-
-
+				else {
+					# Something else has happened; Let the error bubble up
+					throw
+				}
 			}
-			catch {
-				throw
-			}
-
 		}
+
 
 		# Iterate through each machine that we could make a WMI connection to and gather information
 		# Some machines may have multiple entries (b\c of multiple IP Addresses) so only use the first IP Address for each
@@ -2386,14 +1905,14 @@ function Find-SqlServerService {
 			#Add the runspace into the PowerShell instance
 			$PowerShell.RunspacePool = $RunspacePool
 
-			$null = $Runspaces.Add((
+			$Runspaces.Add((
 					New-Object -TypeName PsObject -Property @{
-						PowerShell   = $PowerShell
-						Runspace     = $PowerShell.BeginInvoke()
+						PowerShell = $PowerShell
+						Runspace = $PowerShell.BeginInvoke()
 						ComputerName = $($_.Group[0]).DnsRecordName
-						IPAddress    = $($_.Group[0]).IPAddress
+						IPAddress = $($_.Group[0]).IPAddress
 					}
-			))
+				)) | Out-Null
 		}
 
 		# Reset the scan counter
@@ -2410,29 +1929,20 @@ function Find-SqlServerService {
 						$Runspace.PowerShell.EndInvoke($Runspace.Runspace) | ForEach-Object {
 							$Service.Service += $_
 
-							if (-not [String]::IsNullOrEmpty($_.ServiceIpAddress)) {
-							} else {
-							}
-
-
 							if ($_.IsNamedInstance -eq $true) {
-								if ([String]::IsNullOrEmpty($_.ServiceIpAddress)) {
-									Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) named instance $($_.ServerName)" -MessageLevel Information
-								} else {
-									Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) named instance $($_.ServerName) on IP address $($_.ServiceIpAddress)" -MessageLevel Information
-								}
+								Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) named instance $($_.ServerName) at IP address $($_.ServiceIpAddress)" -MessageLevel Information
 							} else {
-								if ([String]::IsNullOrEmpty($_.ServiceIpAddress)) {
-									Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) default instance $($_.ServerName)" -MessageLevel Information
-								} else {
-									Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) default instance $($_.ServerName) on IP address $($_.ServiceIpAddress)" -MessageLevel Information
-								}
+								Write-NetworkScanLog -Message "Found $($_.ServiceTypeName) default instance $($_.ServerName) at IP address $($_.ServiceIpAddress)" -MessageLevel Information
 							}
 						}
 
 					}
 					catch {
+						#if ($_.Exception.Message -ilike '*SQL Server WMI provider is not available*') {
+						#	Write-NetworkScanLog -Message "ERROR: Unable to retrieve service information from $($Runspace.ComputerName) ($($Runspace.IPAddress)). The SQL Server WMI provider may need to be installed on $($Runspace.ComputerName)." -MessageLevel Information
+						#} else {
 						Write-NetworkScanLog -Message "ERROR: Unable to retrieve service information from $($Runspace.ComputerName) ($($Runspace.IPAddress)): $($_.Exception.Message)" -MessageLevel Information
+						#} 
 					}
 					finally {
 						# Cleanup
@@ -2447,14 +1957,14 @@ function Find-SqlServerService {
 			Start-Sleep -Milliseconds 250
 
 			# Clean out unused runspace jobs
-			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $null) } | ForEach-Object {
+			$Runspaces.clone() | Where-Object { ($_.Runspace -eq $Null) } | ForEach {
 				$Runspaces.remove($_)
 				$ScanCount++
 				Write-Progress -Activity 'Scanning for SQL Services' -PercentComplete (($ScanCount / $WmiDeviceCount)*100) -Status "Device $ScanCount of $WmiDeviceCount" -Id $SqlScanProgressId -ParentId $ParentProgressId
 			}
 
 
-		} while (($Runspaces | Where-Object {$_.Runspace -ne $null} | Measure-Object).Count -gt 0)
+		} while (($Runspaces | Where-Object {$_.Runspace -ne $Null} | Measure-Object).Count -gt 0)
 		#endregion
 
 		# Finally, close the runspaces


### PR DESCRIPTION
…" with "1" argument(s): "You cannot call a method on a null-valued expression."

Issue caused by 'SQL Server Launchpad' servicetype not defined in the 'case switch' command inside the scriptblock.
I've added type '12' and changed the 'default' to something more meaningfull to avoid null valued expressions errors should this occur again in the future.